### PR TITLE
Fix: Prevent timer briefly showing increased remaining time on start

### DIFF
--- a/components/TimerDisplay.tsx
+++ b/components/TimerDisplay.tsx
@@ -33,7 +33,10 @@ export const TimerDisplay: React.FC<TimerDisplayProps> = ({ task }) => {
     if (task.timerStatus === TimerStatus.PAUSED) return task.accumulatedTime;
     // RUNNING or FINISHED (overtime)
     if (task.timerStartTime) {
-      return task.accumulatedTime + (currentTime - task.timerStartTime);
+      // Ensure the difference is not negative, which can happen due to slight async delay
+      // between setting timerStartTime and rendering with currentTime.
+      const currentIntervalElapsedTime = Math.max(0, currentTime - task.timerStartTime);
+      return task.accumulatedTime + currentIntervalElapsedTime;
     }
     // Fallback, though timerStartTime should be set if running/finished
     return task.accumulatedTime; 


### PR DESCRIPTION
The timer display could momentarily show an increased remaining time (e.g., adding a second) when you started a timer. This was due to a potential race condition where the `currentTime` state in `TimerDisplay.tsx` could be sampled slightly before the `timerStartTime` prop (set in `App.tsx`) was fully updated and propagated. This could lead to a small negative calculated elapsed time for the initial interval, which, when subtracted from the estimated duration, incorrectly increased the displayed remaining time.

The fix ensures that the calculated elapsed time for the current running interval in `getEffectiveElapsedTimeMs` in `TimerDisplay.tsx` is never negative by using `Math.max(0, currentTime - task.timerStartTime)`. This correctly reflects that zero time has passed in the new interval if `currentTime` is (momentarily) earlier than `timerStartTime`.