### PR TITLE
Add basic App render test

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import App from '../App';
+
+// jsdom does not implement matchMedia, so provide a minimal mock
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+describe('App', () => {
+  it('renders without crashing', () => {
+    render(<App />);
+    expect(screen.getByRole('heading', { name: /advanced todo list/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add new test file to ensure `App` renders without crashing
- provide mock for `window.matchMedia` in the test

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc171fa9c8321ad1692ea995f2038