### PR TITLE
Add beep sound for completed timers

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { AddTaskForm } from './components/AddTaskForm';
 import { TaskList } from './components/TaskList';
 import { Notification } from './components/Notification';
 import { MoonIcon, SunIcon } from './components/icons';
+import { playBeep } from './utils/beep';
 
 const App: React.FC = () => {
   const [tasks, setTasks] = useState<Task[]>(() => {
@@ -38,9 +39,10 @@ const App: React.FC = () => {
     setDarkMode(!darkMode);
   };
 
-  const showAppNotification = (message: string, taskId: string) => {
+const showAppNotification = (message: string, taskId: string) => {
     setNotification({ id: Date.now().toString(), message, taskId });
-  };
+    playBeep();
+};
 
   const dismissNotification = () => {
     setNotification(null);

--- a/utils/beep.ts
+++ b/utils/beep.ts
@@ -1,0 +1,19 @@
+export function playBeep(duration: number = 200, frequency: number = 880) {
+  if (typeof window === 'undefined') return;
+  const AudioCtx = (window.AudioContext || (window as any).webkitAudioContext);
+  if (!AudioCtx) return;
+
+  const ctx = new AudioCtx();
+  const oscillator = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  oscillator.type = 'sine';
+  oscillator.frequency.value = frequency;
+  gain.gain.value = 0.1;
+
+  oscillator.connect(gain);
+  gain.connect(ctx.destination);
+  oscillator.start();
+  oscillator.stop(ctx.currentTime + duration / 1000);
+  oscillator.onended = () => ctx.close();
+}


### PR DESCRIPTION
## Summary
- notify user with a short beep when a timer completes
- implement lightweight Web Audio beep utility
- wire beep into notification logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404b7bc7848321b391a900b326dec7