### PR TITLE
Add screen wake lock for running timers

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { Task, TimerStatus, NotificationMessage } from './types';
+import { useScreenWakeLock } from './hooks/useScreenWakeLock';
 import { AddTaskForm } from './components/AddTaskForm';
 import { TaskList } from './components/TaskList';
 import { Notification } from './components/Notification';
@@ -19,6 +20,11 @@ const App: React.FC = () => {
      }
      return false;
   });
+
+  const anyTimerRunning = tasks.some(
+    t => t.timerStatus === TimerStatus.RUNNING || t.timerStatus === TimerStatus.FINISHED
+  );
+  useScreenWakeLock(anyTimerRunning);
 
   useEffect(() => {
     localStorage.setItem('todoTasks', JSON.stringify(tasks));

--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ This contains everything you need to run your app locally.
 - **User Experience:**
     - Dark mode support, with a toggle and detection of system preference.
     - Notifications for events like timer completion.
+    - Uses the Screen Wake Lock API to keep the screen on while a timer is running (falls back gracefully if unsupported).

--- a/hooks/useScreenWakeLock.ts
+++ b/hooks/useScreenWakeLock.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Requests a screen wake lock while `active` is true. The lock is released when
+ * `active` becomes false or the component using this hook unmounts. If the page
+ * becomes visible again after being hidden, the lock is re-requested.
+ */
+export function useScreenWakeLock(active: boolean): void {
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const requestLock = async () => {
+      if (!active || !('wakeLock' in navigator)) return;
+      try {
+        wakeLockRef.current = await navigator.wakeLock.request('screen');
+      } catch (err) {
+        console.error('Failed to acquire wake lock', err);
+      }
+    };
+
+    const releaseLock = async () => {
+      try {
+        await wakeLockRef.current?.release();
+      } catch {
+        // ignore
+      } finally {
+        wakeLockRef.current = null;
+      }
+    };
+
+    if (active) {
+      requestLock();
+    } else {
+      releaseLock();
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && active) {
+        requestLock();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      releaseLock();
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## Summary
- keep screen active with new `useScreenWakeLock` hook
- use wake lock in `App` when any timer is active
- document wake lock behavior

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404c08cdf483219607f55fbe6644de