### PR TITLE
Fix drag leave null check

### DIFF
--- a/components/TaskList.tsx
+++ b/components/TaskList.tsx
@@ -110,7 +110,8 @@ export const TaskList: React.FC<TaskListProps> = ({
 
   const handleDragLeaveList = (event: React.DragEvent<HTMLDivElement>) => {
     // Check if the mouse is leaving the list container towards an unrelated element
-    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+    const relatedTarget = event.relatedTarget as Node | null;
+    if (relatedTarget && !event.currentTarget.contains(relatedTarget)) {
         setDropTargetIndex(null);
     }
   };


### PR DESCRIPTION
## Summary
- guard drag leave handler against null relatedTarget

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841565cc0788321bc62ddf514af32c4