### PR TITLE
Add Notification component test

### DIFF
--- a/__tests__/Notification.test.tsx
+++ b/__tests__/Notification.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Notification, AUTO_DISMISS_DURATION, ANIMATION_DURATION } from '../components/Notification';
+import { NotificationMessage } from '../types';
+
+describe('Notification', () => {
+  const sampleNotification: NotificationMessage = {
+    id: '1',
+    message: 'Test notification',
+    taskId: 'task-1'
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('auto dismisses after AUTO_DISMISS_DURATION', async () => {
+    const onDismiss = jest.fn();
+    render(<Notification notification={sampleNotification} onDismiss={onDismiss} />);
+    await act(() => {
+      jest.advanceTimersByTime(0);
+    });
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+
+    await act(() => {
+      jest.advanceTimersByTime(AUTO_DISMISS_DURATION);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    await act(() => {
+      jest.advanceTimersByTime(ANIMATION_DURATION);
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses when button clicked and clears timers', async () => {
+    const onDismiss = jest.fn();
+    render(<Notification notification={sampleNotification} onDismiss={onDismiss} />);
+    await act(() => {
+      jest.advanceTimersByTime(0);
+    });
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(screen.getByRole('button', { name: /dismiss notification/i }));
+    await act(() => {
+      jest.advanceTimersByTime(ANIMATION_DURATION);
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    await act(() => {
+      jest.advanceTimersByTime(AUTO_DISMISS_DURATION);
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/Notification.tsx
+++ b/components/Notification.tsx
@@ -9,8 +9,8 @@ interface NotificationProps {
 
 import { CheckCircleIcon } from './icons'; // Assuming CheckCircleIcon is available
 
-const ANIMATION_DURATION = 300; // ms
-const AUTO_DISMISS_DURATION = 5000; // ms
+export const ANIMATION_DURATION = 300; // ms
+export const AUTO_DISMISS_DURATION = 5000; // ms
 
 export const Notification: React.FC<NotificationProps> = ({ notification, onDismiss }) => {
   const [show, setShow] = React.useState(false);


### PR DESCRIPTION
## Summary
- export timing constants from `Notification`
- test `Notification` auto-dismiss and manual dismiss behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841a60c28f0832199c50baefb1ed312