### PR TITLE
Add delete animation test for TaskItem

### DIFF
--- a/__tests__/TaskItem.test.tsx
+++ b/__tests__/TaskItem.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TaskItem } from '../components/TaskItem';
+import { TimerStatus, Task } from '../types';
+import React from 'react';
+import { act } from 'react';
+
+describe('TaskItem', () => {
+  it('calls onActualDeleteTask after delete animation', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const task: Task = {
+      id: 'task-1',
+      text: 'Test task',
+      estimatedDuration: 60,
+      isCompleted: false,
+      timerStatus: TimerStatus.IDLE,
+      accumulatedTime: 0,
+      timerStartTime: null,
+    };
+
+    const onActualDeleteTask = jest.fn();
+
+    render(
+      <TaskItem
+        task={task}
+        onToggleComplete={jest.fn()}
+        onStartTimer={jest.fn()}
+        onPauseTimer={jest.fn()}
+        onResetTimer={jest.fn()}
+        onSetTaskTimerStatus={jest.fn()}
+        onActualDeleteTask={onActualDeleteTask}
+        isDragging={false}
+        onDragStart={jest.fn()}
+        onDragOver={jest.fn()}
+        onDragEnd={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /delete task/i }));
+    expect(onActualDeleteTask).not.toHaveBeenCalled();
+
+    await act(() => {
+      jest.advanceTimersByTime(350);
+      return Promise.resolve();
+    });
+
+    expect(onActualDeleteTask).toHaveBeenCalledWith(task.id);
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- verify that TaskItem's delayed delete calls `onActualDeleteTask`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841a6122ab483219f7377b4f4a318bb