### PR TITLE
Fix timer display on undo completion

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -108,11 +108,13 @@ const showAppNotification = (message: string, taskId: string) => {
               };
             }
           } else {
-            // Task is being marked as incomplete - reset timer state
+            // Task is being marked as incomplete
+            // If there is accumulated time, preserve it and show remaining time
             return {
               ...task,
               isCompleted: false,
-              timerStatus: TimerStatus.IDLE,
+              timerStatus:
+                task.accumulatedTime > 0 ? TimerStatus.PAUSED : TimerStatus.IDLE,
               timerStartTime: null
             };
           }

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import userEvent from "@testing-library/user-event";
+import { render, screen, act } from '@testing-library/react';
 import React from 'react';
 import App from '../App';
 
@@ -24,4 +25,30 @@ describe('App', () => {
     render(<App />);
     expect(screen.getByRole('heading', { name: /advanced todo list/i })).toBeInTheDocument();
   });
+});
+
+
+
+it('shows remaining time when marking a completed task as incomplete', async () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2021-01-01T00:00:00Z'));
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  const { findByRole, getByRole, findByText } = render(<App />);
+
+  await user.type(getByRole('textbox', { name: /task description/i }), 'Test task');
+  await user.type(getByRole('spinbutton', { name: /estimated duration in minutes/i }), '1');
+  await user.click(getByRole('button', { name: /add task/i }));
+
+  await user.click(getByRole('button', { name: /start timer/i }));
+  await act(() => {
+    jest.advanceTimersByTime(5000);
+  });
+
+  await user.click(getByRole('button', { name: /mark task as complete/i }));
+  await findByText('00:05');
+
+  await user.click(getByRole('button', { name: /mark task as incomplete/i }));
+  await findByText('00:55');
+  jest.useRealTimers();
 });


### PR DESCRIPTION
## Summary
- preserve timer pause state when marking a completed task as incomplete
- test reverting a completed task back to incomplete
- import `act` at the top of the App test instead of using `require`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841ab37b8e483218c95fec1e3d73eba